### PR TITLE
[#28] 전시 상세 조회시 작가들이 중복으로 조회되는 에러 수정

### DIFF
--- a/src/main/java/com/superposition/art/dto/ResponseExhibitionDetail.java
+++ b/src/main/java/com/superposition/art/dto/ResponseExhibitionDetail.java
@@ -3,6 +3,7 @@ package com.superposition.art.dto;
 import com.superposition.artist.dto.ArtistInfo;
 import com.superposition.product.dto.ResponseProduct;
 import java.util.List;
+import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -15,5 +16,5 @@ public class ResponseExhibitionDetail {
     private String title;
     private String subHeading;
     private List<ResponseProduct> productInfo;
-    private List<ArtistInfo> artistInfo;
+    private Set<ArtistInfo> artistInfo;
 }

--- a/src/main/java/com/superposition/artist/dto/ArtistInfo.java
+++ b/src/main/java/com/superposition/artist/dto/ArtistInfo.java
@@ -1,5 +1,6 @@
 package com.superposition.artist.dto;
 
+import java.util.Objects;
 import lombok.Getter;
 
 @Getter
@@ -10,4 +11,21 @@ public class ArtistInfo {
     private boolean isDisplay;
     private String description;
     private String instagramId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ArtistInfo that = (ArtistInfo) o;
+        return Objects.equals(getInstagramId(), that.getInstagramId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getInstagramId());
+    }
 }

--- a/src/test/java/com/superposition/art/service/ExhibitionServiceTest.java
+++ b/src/test/java/com/superposition/art/service/ExhibitionServiceTest.java
@@ -276,11 +276,13 @@ class ExhibitionServiceTest {
         assertThat(actual.getSubHeading()).isEqualTo(
                 "The Met continues a longstanding holiday tradition with the presentation of its Christmas tree.");
         assertThat(actual.getProductInfo())
-                .hasSize(3)
+                .hasSize(4)
                 .extracting("productId", "picture", "tags", "title", "artist")
                 .containsExactlyInAnyOrder(
                         tuple(1L, "6e305a70-0ed7-4f40-a59e-e28bb495887d.jpg", new String[]{"청량한", "맑은", "아련한"},
                                 "roses", "문소"),
+                        tuple(2L, "133ce073-7a2c-4946-a125-1693940d3720.jpg", new String[]{"청량한", "일상적인", "자유로운"},
+                                "highway", "문소"),
                         tuple(13L, "e58b394b-c0dd-4992-be70-3a258a1fc061.png", new String[]{"따뜻한", "귀여운", "포근한"},
                                 "christmas in my hand", "삼이공"),
                         tuple(20L, "14fcf569-2c1b-482f-93cf-a78c65b01aa5.jpg", new String[]{"웅장한", "묘한", "상징적인"},

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -89,7 +89,7 @@ INSERT INTO product (product_id, picture, title, artist_name, description, price
 VALUES (1, '6e305a70-0ed7-4f40-a59e-e28bb495887d.jpg', 'roses', '문소', '나를 위로해주는 아름다운 장미, 그리고 음악과 함께 떠오르는 아련한 기억',
         250000, 21, 2, 2, 3, 1),
        (2, '133ce073-7a2c-4946-a125-1693940d3720.jpg', 'highway', '문소', '여행의 설레임과 즐거움 속에 언제나 함께하는 사랑스러운 너.', 350000, 10,
-        5, 3, 1, NULL),
+        5, 3, 1, 1),
        (3, 'a68ebb31-d1a3-4bfa-9ac1-66aaa247da85.jpg', '우리들', '문소', '맛있는 빵가게는 그냥 지나칠 수 없지!', 100000, 8, 6, 2, 0, NULL),
        (4, '2fe94166-0dd0-40d2-af57-f5e1ca56db0a.jpg', 'How Deep Is Your Love?', '문소', '당신의 사랑은 어느 정도 일까?', 100000, 6,
         0, 0, 0, NULL),


### PR DESCRIPTION
- 전시 상세 조회시 한 작가가 여러 작품을 전시한 경우 전시한 작품 수만큼 작가 정보를 반환하는 에러를 수정